### PR TITLE
Add the ability for configuring the server with a config file.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/dione-server/Cargo.toml
+++ b/dione-server/Cargo.toml
@@ -12,6 +12,9 @@ tokio = { version = "1.7", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = "0.2.18"
 adler = { version = "1.0.2", default-features = false }
+serde_derive = "1"
+serde = {version = "1", features = ["serde_derive"]}
+toml = "0.5"
 
 [build-dependencies]
 tonic-build = "0.4"

--- a/dione-server/config/dev_config.toml
+++ b/dione-server/config/dev_config.toml
@@ -1,0 +1,9 @@
+node_name = "Dev-Node-1"
+
+[network_con.message_storage]
+ip = "127.0.0.1"
+port = 50051
+
+[network_con.conf_retrv]
+ip = "127.0.0.1"
+port = 2000

--- a/dione-server/src/config/conf_ex.rs
+++ b/dione-server/src/config/conf_ex.rs
@@ -1,0 +1,43 @@
+use serde_derive::Deserialize;
+use std::str::FromStr;
+use std::path::Path;
+use std::fs::read_to_string;
+use std::net::{SocketAddr, IpAddr};
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct NetworkCon {
+    ip: String,
+    port: u16,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct Conf {
+    pub node_name: String,
+    pub network_con: Services,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct Services {
+    pub message_storage: NetworkCon,
+    pub conf_retrv: Option<NetworkCon>,
+}
+
+impl FromStr for Conf {
+    type Err = toml::de::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let path = Path::new(s);
+        let str = read_to_string(path).expect("No Config file");
+        println!("String => {}", str);
+        toml::from_str(&str)
+    }
+}
+
+impl From<NetworkCon> for SocketAddr {
+    fn from(conf: NetworkCon) -> Self {
+        let ip_str = conf.ip;
+        let ip = IpAddr::from_str(&ip_str)
+            .expect("Error parsing IP-Address");
+        SocketAddr::new(ip, conf.port)
+    }
+}

--- a/dione-server/src/config/mod.rs
+++ b/dione-server/src/config/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod conf_ex;

--- a/dione-server/src/main.rs
+++ b/dione-server/src/main.rs
@@ -2,15 +2,21 @@ use tonic::transport::Server;
 use tracing::Level;
 
 use crate::tonic_responder::save_message::MessageStorer;
+use std::str::FromStr;
+use std::path::Path;
+use crate::config::conf_ex::Conf;
 
 pub(crate) mod message_storage {
 	tonic::include_proto!("messagestorage");
 }
 
 mod tonic_responder;
+mod config;
 
 #[tokio::main]
 async fn main() {
+	let config: Conf = crate::config::conf_ex::Conf::from_str("dione-server/config/dev_config.toml").unwrap();
+
 	let collector = tracing_subscriber::fmt()
 		.with_max_level(Level::DEBUG)
 		.finish();
@@ -18,7 +24,7 @@ async fn main() {
 	tracing::subscriber::set_global_default(collector)
 		.expect("Something fucked up during setting up collector");
 
-	let addr = "[::1]:50051".parse().unwrap();
+	let addr= config.network_con.message_storage.into();
 	let greeter = MessageStorer::default();
 
 	println!("Storer listening on {}", addr);


### PR DESCRIPTION
This is just a rudimentary implementation staticly linking to the dev-config file. In a future commit this will be either retrieved from Enviroment variables or from an argument. However this makes developing harder so this change will be postponed for now.